### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/helm/wordpress-article-mapper/templates/service.yaml
+++ b/helm/wordpress-article-mapper/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true"
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}"
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080

--- a/helm/wordpress-article-mapper/values.yaml
+++ b/helm/wordpress-article-mapper/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/wordpress-article-mapper

--- a/src/main/java/com/ft/wordpressarticlemapper/health/RemoteServiceDependencyHealthCheck.java
+++ b/src/main/java/com/ft/wordpressarticlemapper/health/RemoteServiceDependencyHealthCheck.java
@@ -85,7 +85,7 @@ public class RemoteServiceDependencyHealthCheck extends AdvancedHealthCheck {
 
     @Override
     protected int severity() {
-        return 1;
+        return 2;
     }
 
     @Override


### PR DESCRIPTION
- mappers aren't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red