### PR TITLE
Extract img tags that are nested inside span tags as well

### DIFF
--- a/src/test/java/com/ft/wordpressarticlemapper/transformer/BodyProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/wordpressarticlemapper/transformer/BodyProcessingFieldTransformerFactoryTest.java
@@ -8,9 +8,11 @@ import com.ft.bodyprocessing.transformer.FieldTransformer;
 import com.ft.wordpressarticlemapper.configuration.BlogApiEndpointMetadataManager;
 import com.ft.wordpressarticlemapper.model.BlogApiEndpointMetadata;
 import com.ft.wordpressarticlemapper.util.ClientMockBuilder;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.sun.jersey.api.client.Client;
+
 import org.hamcrest.text.IsEqualIgnoringWhiteSpace;
 import org.junit.Before;
 import org.junit.Rule;
@@ -412,23 +414,20 @@ public class BodyProcessingFieldTransformerFactoryTest {
 
     @Test
     public void thatImagesAreExtractedFromParagraphs() {
-        String bodyWithImages = "<body>" +
-                "<p><img src=\"img1\"/></p>" +
-                "<p><img src=\"img2\"/>Lorem ipsum</p>" +
-                "<p><a href=\"\"><img src=\"img3\"/>" +
-                "<img src=\"img4\"/></a></p>" +
-                "<p><a href=\"\">Lorem ipsum<img src=\"img5\"/></a>" +
-                "</body>";
+        String bodyWithImages = "<body><p>Lorem ipsum</p>" +
+                "<p>" +
+                "Text before img <img src=\"img source\"/> Text after img " +
+                "Text before a tag <a href=\"\"><img src=\"img source\"/></a> Text after a tag " +
+                "Text before span tag <span><a href=\"\"><img src=\"img source\"/></a></span> Text after span tag" +
+                "</p>" +
+                "<p>Lorem ipsum</p></body>";
 
-        String expectedTransformed = "<body>" +
-                "<img src=\"img1\"/>" +
-                "<img src=\"img2\"/>" +
-                "<p>Lorem ipsum</p>" +
-                "<img src=\"img3\"/>" +
-                "<img src=\"img4\"/>" +
-                "<img src=\"img5\"/>" +
-                "<p><a href=\"\">Lorem ipsum</a></p>" +
-                "</body>";
+        String expectedTransformed = "<body><p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/>" +
+                "<img src=\"img source\"/>" +
+                "<img src=\"img source\"/>" +
+                "<p>Text before img   Text after img Text before a tag  Text after a tag Text before span tag  Text after span tag</p>" +
+                "<p>Lorem ipsum</p></body>";
 
         checkTransformation(bodyWithImages, expectedTransformed);
     }

--- a/src/test/java/com/ft/wordpressarticlemapper/transformer/BodyProcessingFieldTransformerFactoryTest.java
+++ b/src/test/java/com/ft/wordpressarticlemapper/transformer/BodyProcessingFieldTransformerFactoryTest.java
@@ -415,18 +415,61 @@ public class BodyProcessingFieldTransformerFactoryTest {
     @Test
     public void thatImagesAreExtractedFromParagraphs() {
         String bodyWithImages = "<body><p>Lorem ipsum</p>" +
-                "<p>" +
-                "Text before img <img src=\"img source\"/> Text after img " +
-                "Text before a tag <a href=\"\"><img src=\"img source\"/></a> Text after a tag " +
-                "Text before span tag <span><a href=\"\"><img src=\"img source\"/></a></span> Text after span tag" +
-                "</p>" +
+                "<p><img src=\"source\"/></p>" +
+                "<p><img src=\"source\"/><img src=\"source\"/></p>" +
+                "<p>Before img<img src=\"source\"/></p>" +
+                "<p><img src=\"source\"/>After img</p>" +
+                "<p><img src=\"source\"/><em/></p>" +
+                "<p><em/><img src=\"source\"/></p>" +
+                "<p><em><img src=\"source\"/></em></p>" +
+                "<p><em>Inside em tag<img src=\"source\"/></em></p>" +
+
+                "<p><a href=\"\"><img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></p>" +
+                "<p>Before a tag<a href=\"\"><img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/></a>After a tag</p>" +
+                "<p><a href=\"\"><img src=\"source\"/></a><em/></p>" +
+                "<p><em/><a href=\"\"><img src=\"source\"/></a></p>" +
+                "<p><em><a href=\"\"><img src=\"source\"/></a></em></p>" +
+                "<p><a href=\"\">Inside a tag<img src=\"source\"/></a></p>" +
+
+                "<p><span><a href=\"\"><img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></span></p>" +
+                "<p>Before span<span><a href=\"\"><img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a></span>After span</p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a></span><em/></p>" +
+                "<p><em/><span><a href=\"\"><img src=\"source\"/></a></span></p>" +
+                "<p><em><span><a href=\"\"><img src=\"source\"/></a></span></em></p>" +
+                "<p><em>Inside em<span><a href=\"\"><img src=\"source\"/></a></span></em></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String expectedTransformed = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/>" +
-                "<img src=\"img source\"/>" +
-                "<img src=\"img source\"/>" +
-                "<p>Text before img   Text after img Text before a tag  Text after a tag Text before span tag  Text after span tag</p>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><img src=\"source\"/>" +
+                "<img src=\"source\"/><p>Before img</p>" +
+                "<img src=\"source\"/><p>After img</p>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><p><em>Inside em tag</em></p>" +
+
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><img src=\"source\"/>" +
+                "<img src=\"source\"/><p>Before a tag</p>" +
+                "<img src=\"source\"/><p>After a tag</p>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><p><a href=\"\">Inside a tag</a></p>" +
+
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><img src=\"source\"/>" +
+                "<img src=\"source\"/><p>Before span</p>" +
+                "<img src=\"source\"/><p>After span</p>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/>" +
+                "<img src=\"source\"/><p><em>Inside em</em></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         checkTransformation(bodyWithImages, expectedTransformed);

--- a/src/test/java/com/ft/wordpressarticlemapper/transformer/ImageExtractorBodyProcessorTest.java
+++ b/src/test/java/com/ft/wordpressarticlemapper/transformer/ImageExtractorBodyProcessorTest.java
@@ -37,12 +37,25 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_ExtractImgWhenItIsTheOnlyThingInTheParagraph() {
+    public void testProcess_DeleteImageWithEmptySrcFromParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><img src=\"img source\"/></p>" +
+                "<p><img src=\"\"/></p>" +
+                "<p><img src=\"\"/><img src=\"source\"/></p>" +
+                "<p>Before img<img src=\"\"/></p>" +
+                "<p><img src=\"\"/>After img</p>" +
+                "<p><img src=\"\"/><non-deletable/></p>" +
+                "<p><non-deletable/><img src=\"\"/></p>" +
+                "<p><a href=\"\"><img src=\"\"/></a></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p/>" +
+                "<p/>" +
+                "<img src=\"source\"/><p/>" +
+                "<p>Before img</p>" +
+                "<p>After img</p>" +
+                "<p><non-deletable/></p>" +
+                "<p><non-deletable/></p>" +
+                "<p/>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -50,14 +63,24 @@ public class ImageExtractorBodyProcessorTest {
         assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
     }
 
-
     @Test
-    public void testProcess_ExtractImgWhenItIsNotTheOnlyThingInTheParagraph() {
+    public void testProcess_DeleteImageWithMissingSrcFromParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <img src=\"img source\"/> Text after img</p>" +
+                "<p><img/></p>" +
+                "<p><img/><img src=\"source\"/></p>" +
+                "<p>Before img<img src=\"\"/></p>" +
+                "<p><img/>After img</p>" +
+                "<p><img/><non-deletable/></p>" +
+                "<p><non-deletable/><img/></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p>Text before img  Text after img</p>" +
+                "<p/>" +
+                "<img src=\"source\"/><p/>" +
+                "<p>Before img</p>" +
+                "<p>After img</p>" +
+                "<p><non-deletable/></p>" +
+                "<p><non-deletable/></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -66,12 +89,23 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_ExtractImgInsideATag() {
+    public void testProcess_ExtractImageFromParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <a href=\"\">Lorem ipsum<img src=\"img source\"/></a> Text after image</p>" +
+                "<p><img src=\"source\"/></p>" +
+                "<p><img src=\"source\"/><img src=\"source\"/></p>" +
+                "<p>Before img<img src=\"source\"/></p>" +
+                "<p><img src=\"source\"/>After img</p>" +
+                "<p><img src=\"source\"/><non-deletable/></p>" +
+                "<p><non-deletable/><img src=\"source\"/></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p>Text before img  Text after image</p>" +
+                "<img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><p>Before img</p>" +
+                "<img src=\"source\"/><p>After img</p>" +
+                "<img src=\"source\"/><p><non-deletable/></p>" +
+                "<img src=\"source\"/><p><non-deletable/></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -80,12 +114,23 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_ExtractImgInsideSpanTag() {
+    public void testProcess_ExtractImageFromNonDeletableTag() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <span><a href=\"\"><img src=\"img source\"/></a></span> Text after img</p>" +
+                "<p><em><span><a href=\"\"><img src=\"source\"/></a></span></em></p>" +
+                "<p><em><span><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></span></em></p>" +
+                "<p><em><span><a href=\"\"><img src=\"source\"/></a></span><span><a href=\"\"><img src=\"source\"/></a></span></em></p>" +
+                "<p><em>Before span<span><a href=\"\"><img src=\"source\"/></a></span> After span</em></p>" +
+                "<p><em><span>Before a tag<a href=\"\"><img src=\"source\"/></a> After a tag</span></em></p>" +
+                "<p><em><span><a href=\"\">Before img<img src=\"source\"/> After img</a> After a tag</span></em></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p>Text before img  Text after img</p>" +
+                "<img src=\"source\"/><p><em/></p>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><em/></p>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><em/></p>" +
+                "<img src=\"source\"/><p><em>Before span After span</em></p>" +
+                "<img src=\"source\"/><p><em><span>Before a tag After a tag</span></em></p>" +
+                "<img src=\"source\"/><p><em><span><a href=\"\">Before img After img</a> After a tag</span></em></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -94,12 +139,27 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_RemoveImgWithoutSrcInsideParagraph() {
+    public void testProcess_ExtractImageFromSpan() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <img/> Text after img</p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a><a href=\"\"><img src=\"source\"/><non-deletable/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a><a href=\"\"><img src=\"source\"/>After img</a></span></p>" +
+                "<p><span>Before a tag<a href=\"\"><img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/></a>After a tag</span></p>" +
+                "<p><span><a href=\"\">Before img<img src=\"source\"/></a></span></p>" +
+                "<p><span><a href=\"\"><img src=\"source\"/>After img</a></span></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img  Text after img</p>" +
+                "<img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><span><a href=\"\"><non-deletable/></a></span></p>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><span><a href=\"\">After img</a></span></p>" +
+                "<img src=\"source\"/><p><span>Before a tag</span></p>" +
+                "<img src=\"source\"/><p><span>After a tag</span></p>" +
+                "<img src=\"source\"/><p><span><a href=\"\">Before img</a></span></p>" +
+                "<img src=\"source\"/><p><span><a href=\"\">After img</a></span></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -108,119 +168,27 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_RemoveImgWithEmptySrcInsideParagraph() {
+    public void testProcess_ExtractImageFromAnchor() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <img src=\"\"/> Text after img</p>" +
+                "<p><a href=\"\"><img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/>After img</a></p>" +
+                "<p><a href=\"\">Before img<img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/><non-deletable/></a></p>" +
+                "<p><a href=\"\"><non-deletable/><img src=\"source\"/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/></a><a href=\"\"><img src=\"source\"/><non-deletable/></a></p>" +
+                "<p><a href=\"\"><img src=\"source\"/></a><a href=\"\"><img src=\"source\"/>After img</a></p>" +
                 "<p>Lorem ipsum</p></body>";
+
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithoutSrcInsideATag() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <a href=\"\"><img/></a> Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img  Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithEmptySrcInsideATag() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <a href=\"\"><img src=\"\"/></a> Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img  Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithoutSrcInsideSpanTag() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <span><a href=\"\"><img/></a></span> Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img  Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithEmptySrcInsideSpanTag() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img <span><a href=\"\"><img src=\"\"/></a></span> Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Text before img  Text after img</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_ExtractMultipleImgTagsInsideATagWithATagRemoval() {
-        String body = "<body>" +
-                "<p>Text before img <a href=\"\"><img src=\"source\"/><img src=\"source\"/></a> Text after img</p>" +
-                "</body>";
-        String expected = "<body>" +
-                "<img src=\"source\"/><img src=\"source\"/>" +
-                "<p>Text before img  Text after img</p>" +
-                "</body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_ExtractMultipleImgTagsInsideSpanTagWithSpanTagRemoval() {
-        String body = "<body>" +
-                "<p>Text before img <span><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></span> Text after img</p>" +
-                "</body>";
-        String expected = "<body>" +
-                "<img src=\"source\"/><img src=\"source\"/>" +
-                "<p>Text before img  Text after img</p>" +
-                "</body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_ExtractAllImageTypes() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<p>" +
-                "Text before img <img src=\"img source\"/> Text after img " +
-                "Text before a tag <a href=\"\"><img src=\"img source\"/></a> Text after a tag " +
-                "Text before span tag <span><a href=\"\"><img src=\"img source\"/></a></span> Text after span tag" +
-                "</p>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/>" +
-                "<img src=\"img source\"/>" +
-                "<img src=\"img source\"/>" +
-                "<p>Text before img   Text after img Text before a tag  Text after a tag Text before span tag  Text after span tag</p>" +
+                "<img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><p><a href=\"\">After img</a></p>" +
+                "<img src=\"source\"/><p><a href=\"\">Before img</a></p>" +
+                "<img src=\"source\"/><p><a href=\"\"><non-deletable/></a></p>" +
+                "<img src=\"source\"/><p><a href=\"\"><non-deletable/></a></p>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><a href=\"\"><non-deletable/></a></p>" +
+                "<img src=\"source\"/><img src=\"source\"/><p><a href=\"\">After img</a></p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);

--- a/src/test/java/com/ft/wordpressarticlemapper/transformer/ImageExtractorBodyProcessorTest.java
+++ b/src/test/java/com/ft/wordpressarticlemapper/transformer/ImageExtractorBodyProcessorTest.java
@@ -1,10 +1,12 @@
 package com.ft.wordpressarticlemapper.transformer;
 
 import com.ft.bodyprocessing.BodyProcessingContext;
+
 import org.hamcrest.text.IsEqualIgnoringWhiteSpace;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class ImageExtractorBodyProcessorTest {
@@ -21,12 +23,41 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_ExtractImg() {
+    public void testProcess_EmptyBodyDoesNotGetModified() {
+        String result = imageExtractorBodyProcessor.process("", bodyProcessingContext);
+
+        assertThat(result, is(""));
+    }
+
+    @Test
+    public void testProcess_WhitespaceBodyDoesNotGetModified() {
+        String result = imageExtractorBodyProcessor.process("   ", bodyProcessingContext);
+
+        assertThat(result, is("   "));
+    }
+
+    @Test
+    public void testProcess_ExtractImgWhenItIsTheOnlyThingInTheParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><img src=\"img source\"/>Lorem ipsum</p>" +
+                "<p><img src=\"img source\"/></p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/><p/>" +
+                "<p>Lorem ipsum</p></body>";
+
+        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
+
+        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
+    }
+
+
+    @Test
+    public void testProcess_ExtractImgWhenItIsNotTheOnlyThingInTheParagraph() {
+        String body = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img <img src=\"img source\"/> Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
+        String expected = "<body><p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/><p>Text before img  Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -37,10 +68,24 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_ExtractImgInsideATag() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><a href=\"\"><img src=\"img source\"/></a>Lorem ipsum</p>" +
+                "<p>Text before img <a href=\"\">Lorem ipsum<img src=\"img source\"/></a> Text after image</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"img source\"/><p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/><p>Text before img  Text after image</p>" +
+                "<p>Lorem ipsum</p></body>";
+
+        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
+
+        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
+    }
+
+    @Test
+    public void testProcess_ExtractImgInsideSpanTag() {
+        String body = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img <span><a href=\"\"><img src=\"img source\"/></a></span> Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
+        String expected = "<body><p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/><p>Text before img  Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -51,10 +96,10 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_RemoveImgWithoutSrcInsideParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><img/>Lorem ipsum</p>" +
+                "<p>Text before img <img/> Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p>" +
+                "<p>Text before img  Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -65,36 +110,10 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_RemoveImgWithEmptySrcInsideParagraph() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><img src=\"\"/>Lorem ipsum</p>" +
+                "<p>Text before img <img src=\"\"/> Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithoutSrcOutsideParagraph() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<img/>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p></body>";
-
-        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
-
-        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
-    }
-
-    @Test
-    public void testProcess_RemoveImgWithEmptySrcOutsideParagraph() {
-        String body = "<body><p>Lorem ipsum</p>" +
-                "<img src=\"\"/>" +
-                "<p>Lorem ipsum</p></body>";
-        String expected = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -105,10 +124,10 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_RemoveImgWithoutSrcInsideATag() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><a href=\"\"><img/></a>Lorem ipsum</p>" +
+                "<p>Text before img <a href=\"\"><img/></a> Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p>" +
+                "<p>Text before img  Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -119,10 +138,10 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_RemoveImgWithEmptySrcInsideATag() {
         String body = "<body><p>Lorem ipsum</p>" +
-                "<p><a href=\"\"><img src=\"\"/></a>Lorem ipsum</p>" +
+                "<p>Text before img <a href=\"\"><img src=\"\"/></a> Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
-                "<p>Lorem ipsum</p>" +
+                "<p>Text before img  Text after img</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -131,14 +150,27 @@ public class ImageExtractorBodyProcessorTest {
     }
 
     @Test
-    public void testProcess_ExtractMultipleImgTagsInsideATagWithoutRemovingATag() {
-        String body = "<body>" +
-                "<p><a href=\"\"><img src=\"source\"/><img src=\"source\"/>Lorem ipsum</a></p>" +
-                "</body>";
-        String expected = "<body>" +
-                "<img src=\"source\"/><img src=\"source\"/>" +
-                "<p><a href=\"\">Lorem ipsum</a></p>" +
-                "</body>";
+    public void testProcess_RemoveImgWithoutSrcInsideSpanTag() {
+        String body = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img <span><a href=\"\"><img/></a></span> Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
+        String expected = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img  Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
+
+        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
+
+        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
+    }
+
+    @Test
+    public void testProcess_RemoveImgWithEmptySrcInsideSpanTag() {
+        String body = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img <span><a href=\"\"><img src=\"\"/></a></span> Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
+        String expected = "<body><p>Lorem ipsum</p>" +
+                "<p>Text before img  Text after img</p>" +
+                "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
 
@@ -148,10 +180,26 @@ public class ImageExtractorBodyProcessorTest {
     @Test
     public void testProcess_ExtractMultipleImgTagsInsideATagWithATagRemoval() {
         String body = "<body>" +
-                "<p><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></p>" +
+                "<p>Text before img <a href=\"\"><img src=\"source\"/><img src=\"source\"/></a> Text after img</p>" +
                 "</body>";
         String expected = "<body>" +
-                "<img src=\"source\"/><img src=\"source\"/><p/>" +
+                "<img src=\"source\"/><img src=\"source\"/>" +
+                "<p>Text before img  Text after img</p>" +
+                "</body>";
+
+        String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
+
+        assertThat(result, IsEqualIgnoringWhiteSpace.equalToIgnoringWhiteSpace(expected));
+    }
+
+    @Test
+    public void testProcess_ExtractMultipleImgTagsInsideSpanTagWithSpanTagRemoval() {
+        String body = "<body>" +
+                "<p>Text before img <span><a href=\"\"><img src=\"source\"/><img src=\"source\"/></a></span> Text after img</p>" +
+                "</body>";
+        String expected = "<body>" +
+                "<img src=\"source\"/><img src=\"source\"/>" +
+                "<p>Text before img  Text after img</p>" +
                 "</body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);
@@ -163,14 +211,16 @@ public class ImageExtractorBodyProcessorTest {
     public void testProcess_ExtractAllImageTypes() {
         String body = "<body><p>Lorem ipsum</p>" +
                 "<p>" +
-                "<img src=\"img source\"/>" +
-                "<a href=\"\"><img src=\"img source\"/></a>" +
-                "Lorem ipsum</p>" +
+                "Text before img <img src=\"img source\"/> Text after img " +
+                "Text before a tag <a href=\"\"><img src=\"img source\"/></a> Text after a tag " +
+                "Text before span tag <span><a href=\"\"><img src=\"img source\"/></a></span> Text after span tag" +
+                "</p>" +
                 "<p>Lorem ipsum</p></body>";
         String expected = "<body><p>Lorem ipsum</p>" +
                 "<img src=\"img source\"/>" +
                 "<img src=\"img source\"/>" +
-                "<p>Lorem ipsum</p>" +
+                "<img src=\"img source\"/>" +
+                "<p>Text before img   Text after img Text before a tag  Text after a tag Text before span tag  Text after span tag</p>" +
                 "<p>Lorem ipsum</p></body>";
 
         String result = imageExtractorBodyProcessor.process(body, bodyProcessingContext);


### PR DESCRIPTION
- The whole ancestor chain of the `img` up until the paragraph will now be removed. If an ancestor contains nodes that shouldn't be deleted the node, the children that shouldn't be deleted and its ancestors will be kept.
- Other elements that reside outside of this chain inside the paragraph will be retained.